### PR TITLE
[Model Optimizer] Add conv even -> larger odd kernel

### DIFF
--- a/scripts/osrt_model_tools/onnx_tools/tidl-onnx-model-optimizer/tidl_onnx_model_optimizer/src/common.py
+++ b/scripts/osrt_model_tools/onnx_tools/tidl-onnx-model-optimizer/tidl_onnx_model_optimizer/src/common.py
@@ -60,6 +60,7 @@ Common utlity functions and useful graph algorithms
 """
 from typing import List
 import onnx_graphsurgeon as gs
+import onnx
 
 class UniqueIdGenerator:
     """
@@ -196,3 +197,12 @@ def bordered(text):
         res.append('│' + (s + ' ' * width)[:width] + '│')
     res.append('└' + '─' * width + '┘')
     return '\n'.join(res)
+
+def reset_shape_inference(onnx_graph:onnx.GraphProto):
+    '''
+    Clear all value_info entries that hold shape inference information
+    '''
+    while len(onnx_graph.value_info) > 0: 
+        onnx_graph.value_info.pop()
+    return onnx_graph
+

--- a/scripts/osrt_model_tools/onnx_tools/tidl-onnx-model-optimizer/tidl_onnx_model_optimizer/src/conv.py
+++ b/scripts/osrt_model_tools/onnx_tools/tidl-onnx-model-optimizer/tidl_onnx_model_optimizer/src/conv.py
@@ -55,13 +55,15 @@
 # OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 # OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
+
 """
 Module containing Conv layer specific functions and optimizations
 """
 import logging
+import numpy as np
 import onnx_graphsurgeon as gs
 import onnx
-import numpy as np
+import copy
 
 
 def tidl_convert_conv_large_pad_to_smaller_kernel (graph: gs.Graph, onnx_graph: onnx.GraphProto):
@@ -148,3 +150,79 @@ def tidl_convert_conv_large_pad_to_smaller_kernel (graph: gs.Graph, onnx_graph: 
             conv.inputs[1] = gs.Constant(name= f"{weights.name}_reduced",
                                          values=reduced_weight_tensor)
             # bias need not change
+
+
+def tidl_convert_conv_even_filter_to_odd(graph: gs.Graph, onnx_graph: onnx.GraphProto, zero_points={'Conv_Name_Fake_Example': -0.001}):
+    '''
+    Even-sized convolution kernels are not supported in TIDL
+    Replace even-sized kernels with next-size up odd kernels, with padding handled appropriately. Additional filter weights are the zero_points
+
+    :param zero_points: On a per-layer basis, the zero-point for asymmetric quantization. This is a dictionary where key is the layer name, and value is the zero-point for that layer (assumed same for all layers, i.e. no grouping)
+    
+    Some tricks are required here due to Conv layer implementation in TIDL being 'SAME' only. This requires padding be handled outside the layer itself (due to asymmetric pads). Asymmetric quantization is not well supported for these layers, since the zero-point is unknown until calibration. The zero-point fills the additional convolution weights
+    '''
+    #identify conv nodes
+    #find conv nodes w/ even sized kernels
+    #replace even sized kernel with odd, and move values into appropriate shape Constant tensor
+    #reset pad values in conv node
+    #create Pad node that handles all padding, include 'zero point' values?
+    #make Conv input the Pad input, Pad output the Conv input
+
+    conv_nodes = [node for node in graph.nodes if node.op == "Conv"]
+
+    for conv in conv_nodes:
+        kernel_shape = conv.attrs['kernel_shape']
+        pads = conv.attrs['pads']
+        weight_tensor = conv.inputs[1]
+
+        conv_input = conv.inputs[0]
+
+        MAX_SUPPORTED_CONV_KERNEL = 7 #7x7 is largest validated layer size
+        if kernel_shape[0] % 2 == 0 and kernel_shape[0] < MAX_SUPPORTED_CONV_KERNEL and kernel_shape[1] == kernel_shape[0]:
+            logging.debug('Promoting conv node (%s) size (%d x %d) to next size up' % (conv.name, kernel_shape[0], kernel_shape[1]))
+
+            new_size = kernel_shape[0] + 1
+            new_shape = [new_size, new_size]
+
+            zero_p = zero_points.get(conv.name, 0)
+            
+            new_weights_shape = [*weight_tensor.shape[:2], *new_shape]
+
+            # is it correct to put the zero point here or only in the layer padding
+            new_weights = np.full(new_weights_shape, zero_p, dtype=np.float32)
+            # We will pad left and top side of the filter weights with the fill_value / zero-point as we increase the spatial dimensions by 1
+            new_weights[:,:,1:,1:] = weight_tensor.values
+
+            new_weights_tensor = gs.Constant(weight_tensor.name, new_weights)
+            conv.inputs[1] = new_weights_tensor
+
+
+            conv.attrs['kernel_shape'] = new_shape
+            logging.debug('  New conv kernel shape: ')
+
+
+            pad_name = 'Pad/' + conv.name
+
+            pads = copy.copy(pads)
+            pads[0] += 1 # x1 (height) +1  to account for larger filter
+            pads[1] += 1 # x2 (width) +1 to account for larger filter
+            all_pads = np.asarray([0,0, pads[0], pads[1], 0, 0, pads[2], pads[3] ]) #incorporate all dimensions: depending on opset, may not support axis specification 
+            pads_tensor = gs.Constant(pad_name + '_pads', np.asarray(all_pads, np.int64))
+            fill_value_tensor = gs.Constant(pad_name + '_fill', np.asanyarray([zero_p], dtype=np.float32))
+
+
+            conv.attrs['pads'] = [0,0,0,0]
+
+            pad_attrs = {
+                'mode' : 'constant'
+            }
+            pad_inputs = [conv_input, pads_tensor, fill_value_tensor]
+            pad_outputs = [gs.Variable(pad_name+'_output', dtype=conv_input.dtype)]
+
+            logging.debug('  Adding Pad layer with dimensions (%d,%d,%d,%d) and resetting conv pads to 0\'s' % (pads[0], pads[1], pads[2], pads[3]))
+
+            pad_node = gs.Node('Pad', pad_name, pad_attrs, pad_inputs, pad_outputs)
+
+            conv.inputs[0] = pad_outputs[0]
+            graph.nodes.append(pad_node)
+


### PR DESCRIPTION
Adding to model optimizer/conv.py to allow even-sized convolutions to be implemented with larger odd-size. For example, Conv4x4 is replaced with conv5x5. Only square spatial kernels are supported. Padding is added along the top and left sides of the kernel and input. 

Regarding padding, TIDL does not support asymmetric padding on the inputs to Conv layers. Replacing even with next size up odd kernel does require asym padding, so padding is all moved to a preceding, standalone layer, and Conv implements zero-pad 'same' configuration

There is a performance penalty, but this is less drastic than offloading conv operations to CPU as even-sized kernels are not implemented. 

I have checked on a model with 4x4 conv that the conv5x5 gives identical output results