### PR TITLE
for ubuntu 22.04 installation need to find opencv library and include it

### DIFF
--- a/examples/cmake/common.cmake
+++ b/examples/cmake/common.cmake
@@ -55,7 +55,8 @@ else()
   endif()
 endif()
 
-
+find_package(OpenCV REQUIRED)
+include_directories(${OpenCV_INCLUDE_DIRS})
 if (EXISTS $ENV{TIDL_TOOLS_PATH}/osrt_deps/opencv_4.2.0_x86_u22/)
   set(OPENCV_INSTALL_DIR $ENV{TIDL_TOOLS_PATH}/osrt_deps/opencv_4.2.0_x86_u22/)
   message (STATUS  "setting OPENCV_INSTALL_DIR path:${OPENCV_INSTALL_DIR}")


### PR DESCRIPTION
it won't compile on ubunutu 22.04. need to find opencv.
for error   `undefined references to `cv::Mat::Mat()'`