### PR TITLE
fix missing python-setuptools deb package dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The below table covers the supported operations with this repository on X86_PC a
   - Run below one time setup for system level packages. This needs sudo permission, get it installed by your system administrator if required.
 
 ```
-  sudo apt-get install libyaml-cpp-dev
+  sudo apt-get install libyaml-cpp-dev python-setuptools
 ```
 
   - Make sure you have all permission for the current directory before proceeding 


### PR DESCRIPTION
Fixed bug reported in https://github.com/TexasInstruments/edgeai-tidl-tools/issues/85 also copied here for convenience


WARNING: Error parsing dependencies of python-debian: Invalid version: '0.1.36ubuntu1'
pip3 install --no-input git+https://github.com/NVIDIA/TensorRT@release/8.5#subdirectory=tools/onnx-graphsurgeon
Defaulting to user installation because normal site-packages is not writeable
Collecting git+https://github.com/NVIDIA/TensorRT@release/8.5#subdirectory=tools/onnx-graphsurgeon
  Cloning https://github.com/NVIDIA/TensorRT (to revision release/8.5) to /tmp/pip-req-build-uf8qpf84
  Running command git clone --filter=blob:none --quiet https://github.com/NVIDIA/TensorRT /tmp/pip-req-build-uf8qpf84
  Running command git checkout -b release/8.5 --track origin/release/8.5
  Switched to a new branch 'release/8.5'
  Branch 'release/8.5' set up to track remote branch 'release/8.5' from 'origin'.
  Resolved https://github.com/NVIDIA/TensorRT to commit 68b5072fdb9df6b6edab1392b02a705394b2e906
  Running command git submodule update --init --recursive -q
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error