### PR TITLE
Remove extra fi from line 96 update_target.sh rel_11_0 / tag 11_00_08_00

### DIFF
--- a/update_target.sh
+++ b/update_target.sh
@@ -93,7 +93,6 @@ verify_env() {
             echo
             echo "AM62A SDK 11.0 does not exist."
             return 1
-        fi
     fi
 
     if [ "$SOC" == "am62a" ] && [ "$TISDK_IMAGE" == "adas" ]; then


### PR DESCRIPTION
There was a superfluous 'fi' in line 96 which halted the execution of the script and threw an error. Removed now.