### PR TITLE
[Python runtime basic example] Prevent nested output directories in Python basic_example inference

### DIFF
--- a/runtimes/examples/python/basic_example/basic_example.py
+++ b/runtimes/examples/python/basic_example/basic_example.py
@@ -653,11 +653,11 @@ def main():
             
             print(f"Outputs saved: {output_path}")
             for i, data in enumerate(output_data):
-                output_path = os.path.join(output_path, f"frame_{i+1}")
+                output_frame_path = os.path.join(output_path, f"frame_{i+1}")
                 try:
-                    os.makedirs(output_path, exist_ok=True)
+                    os.makedirs(output_frame_path, exist_ok=True)
                 except OSError as e:
-                    print(f"[ERROR] [{model}] Frame:{i} : Cannot create directory for saving output {output_path} : {e}")
+                    print(f"[ERROR] [{model}] Frame:{i} : Cannot create directory for saving output {output_frame_path} : {e}")
                     continue
                 
                 output_binaries = data[0]
@@ -666,13 +666,13 @@ def main():
                 for name, binary in output_binaries.items():
                     out_bin_file = f"{name}.bin"
                     out_bin_file = out_bin_file.replace('/', '_')
-                    out_bin_file = os.path.join(output_path, out_bin_file)
+                    out_bin_file = os.path.join(output_frame_path, out_bin_file)
                     binary.tofile(out_bin_file)
                 
                 for name, data in post_proc_data.items():
                     metadata, image = data
-                    image_path = os.path.join(output_path, f"{name}.jpg")
-                    metadata_path = os.path.join(output_path, f"{name}.txt")
+                    image_path = os.path.join(output_frame_path, f"{name}.jpg")
+                    metadata_path = os.path.join(output_frame_path, f"{name}.txt")
                     image.save(image_path, "JPEG")
                     with open(metadata_path, 'w+') as f:
                         f.write(metadata)


### PR DESCRIPTION
**Minor fix)**
When running inference with multiple frames using python basic_example, 
the output directories are created in a nested structure instead of as siblings which is inconvenient.

I've checked the c++ implementation to verify whether it is a intended behavior, 
but i think it is not intended when looking at the lines L818:L829 in `runtimes/esamples/cpp/basic_example/basic_example.cpp`
```c++
        int32_t status = 0;
        std::string outputDir = fs::path(m_outputsBaseDir) / fs::path(modelName);
        if (!m_disableTIDLOffload)
        {
            outputDir = outputDir / fs::path("offload");
        }
        else
        {
            outputDir = outputDir / fs::path("no_offload");
        }
        outputDir = (outputDir / fs::path("frame_" +std::to_string(frameNo))).string();
        (void) fs::create_directories(outputDir);
```

**Results** 
| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/5b579e81-c3d0-4b57-890d-58a2cf9f5da3" /> | <img src="https://github.com/user-attachments/assets/e379a6bf-f673-4c60-a1cb-b534caa9f9d4" /> |
