### PR TITLE
Fix framework typo in detection post process error

### DIFF
--- a/runtimes/examples/python/utils/post_process/post_process_detection.py
+++ b/runtimes/examples/python/utils/post_process/post_process_detection.py
@@ -30,7 +30,7 @@ class PostProcessDetection():
         if self.framework:
             self.framework = self.framework.strip()
             if self.framework != '' and self.framework not in supported_framework:
-                raise ValueError(f"[ERROR] {self.framwork} self.framework is not currently supported for post processing. Supported frameworks: {', '.join(supported_framework)}")
+                raise ValueError(f"[ERROR] {self.framework} self.framework is not currently supported for post processing. Supported frameworks: {', '.join(supported_framework)}")
 
         elif self.od_type:
             self.od_type = self.od_type.strip()


### PR DESCRIPTION
Fixes a typo in `post_process_detection.py` where `self.framwork` was used instead of `self.framework`.

Without this fix, unsupported framework values can trigger an `AttributeError` instead of the intended `ValueError`.

Validation:
- Ran `python -m py_compile runtimes/examples/python/utils/post_process/post_process_detection.py`